### PR TITLE
Add description of accessibility checking from IPFS gateway

### DIFF
--- a/applications/ipfs_utilities.md
+++ b/applications/ipfs_utilities.md
@@ -21,6 +21,7 @@ In NFT scenario, it would need much more affairs to the validation process on th
 
 This project will follow a different approach. The upload and linking of a file to an NFT e.g. can be done by clients thru one extrinsic. On upload of a file with the IPFS pallet, the pallet will return the ticket id immediately. Once the file is uploaded to IPFS, the CID of the file on IPFS will be stored on chain. The ticket id and CID both can be used to fetch the file via RPC call. While the upload to IPFS is processing, a cache logic can already provide the file based on the ticket id. Once the CID is retrieved and the file is available on IPFS, the cache can be cleared and all fetch requests are redirected to IPFS.
 
+The timing of file accessibility for users is crucial for a web service, and it is hard to make sure in IPFS.  Therefore, A verification request to the public IPFS gateway to check the file we added to IPFS is important.  Once the file can be accessed from the gateway, the upload process will deem complete.  The developer can configure the location of the gateway, and also the system will redirect the requests to the gateway if the file is deemed uploaded completed.  Also, the location format of redirection can be CIDV0 format or CIDV1 format based on the configuration of the developer.  Before the upload is completed, the system could act as a cache server, this feature could be or not be included in the application.
 
 ### Project Details
 


### PR DESCRIPTION
The application wants to make sure the file on IPFS is ready to access from the public gateway.

More specifically, when a website of files adding to IPFS, we want to make sure it can be accessed by everyone via the following links (as examples the gateway is configurable) more than put into a machine running IPFS protocol locally.
- [bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq from cloudflare](https://cloudflare-ipfs.com/ipfs/bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/)
- [bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq from ipfs.io](https://ipfs.io/ipfs/bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/)

The data are already stored on the substrate nodes when uploading by extrinsic no matter whether we do the pin or not.  The purpose behind using the public gateway is about the data is really spread out and not only live in this blockchain network.

Regarding the NFT scenario, the file upload is not only a website but an artwork, and people are active to request and viewing it, the artwork content will live in IPFS, not only on the blockchain network.  This means even if all the validator nodes of this blockchain shut down or are temporarily unavailable, the artwork content will still live on the IPFS internet.  And the ownership is stored on the blockchain network. With this application, the utils help with the availability of IPFS data added from substrate.